### PR TITLE
Incompatibility with nativescript-plugin-firebase

### DIFF
--- a/src/platforms/android/include.gradle
+++ b/src/platforms/android/include.gradle
@@ -30,6 +30,6 @@ android {
 
 dependencies {
 //	compile 'com.android.support:multidex:1.0.0'
-	compile 'com.google.android.gms:play-services-fitness:11.6.0'
-    compile 'com.google.android.gms:play-services-auth:11.6.0'
+	compile 'com.google.android.gms:play-services-fitness:11.8.0'
+    compile 'com.google.android.gms:play-services-auth:11.8.0'
 }


### PR DESCRIPTION
Updated the GMS libraries to 11.8.0 to match the nativescript-plugin-firebase. 