### PR TITLE
add-datatype-cardio

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,7 @@ The reason is I intend to support more units per type, but that is yet to be imp
 | weight | kg | `TYPE_WEIGHT` | `HKQuantityTypeIdentifierBodyMass` |
 | heartRate | count/min | `TYPE_HEART_RATE_BPM` | `HKQuantityTypeIdentifierHeartRate` |
 | fatPercentage | % | `TYPE_BODY_FAT_PERCENTAGE` | `HKQuantityTypeIdentifierBodyFatPercentage` |
+| cardio | min | `TYPE_HEART_POINTS` | `HKQuantityTypeIdentifierAppleExerciseTime` |
 
 ## Credits
 * [Filipe Mendes](https://github.com/filipemendes1994/) for a superb first version of this repo, while working for SPMS, Shared Services for Ministry of Health (of Portugal). He kindly transferred this repo to me when he no longer had time to maintain it.

--- a/demo-ng/src/items/items.component.html
+++ b/demo-ng/src/items/items.component.html
@@ -13,6 +13,7 @@
         <Button text="Get Height (m)" (tap)="getData('height', 'm')"></Button>
         <Button text="Get Weight (kg)" (tap)="getData('weight', 'kg')"></Button>
         <Button text="Get Heart Rate (count/min)" (tap)="getData('heartRate', 'count/min')"></Button>
+        <Button text="Get cardio pts (or minutes)" (tap)="getData('cardio', 'min')"></Button>
         <Button text="Get Fat percentage (%)" (tap)="getData('fatPercentage', '%')"></Button>
         <Button text="Get Calories (Cal)" (tap)="getData('calories', 'kcal')"></Button>
         <Button text="Get Sleep" (tap)="getData('sleep')"></Button>

--- a/demo-ng/src/items/items.component.ts
+++ b/demo-ng/src/items/items.component.ts
@@ -15,7 +15,8 @@ export class ItemsComponent {
     {name: "steps", accessType: "read"},
     {name: "distance", accessType: "read"},
     {name: "heartRate", accessType: "read"},
-    {name: "fatPercentage", accessType: "read"}
+    {name: "fatPercentage", accessType: "read"},
+    {name: "cardio", accessType: "read"}
   ];
 
   private healthData: HealthData;

--- a/src/health-data.android.ts
+++ b/src/health-data.android.ts
@@ -299,7 +299,8 @@ const aggregatedDataTypes = {
   TYPE_WEIGHT: DataType.TYPE_WEIGHT,
   TYPE_HEART_RATE_BPM: DataType.AGGREGATE_HEART_RATE_SUMMARY,
   TYPE_BODY_FAT_PERCENTAGE: DataType.AGGREGATE_BODY_FAT_PERCENTAGE_SUMMARY,
-  TYPE_NUTRITION: DataType.AGGREGATE_NUTRITION_SUMMARY
+  TYPE_NUTRITION: DataType.AGGREGATE_NUTRITION_SUMMARY,
+  TYPE_HEART_POINTS: DataType.TYPE_HEART_POINTS
 };
 
 const acceptableDataTypesForCommonity = {
@@ -310,6 +311,7 @@ const acceptableDataTypesForCommonity = {
   height: 'TYPE_HEIGHT',
   weight: 'TYPE_WEIGHT',
   heartRate: 'TYPE_HEART_RATE_BPM',
-  fatPercentage: 'TYPE_BODY_FAT_PERCENTAGE'
+  fatPercentage: 'TYPE_BODY_FAT_PERCENTAGE',
+  cardio: 'TYPE_HEART_POINTS'
   // "nutrition": "TYPE_NUTRITION",
 };

--- a/src/health-data.ios.ts
+++ b/src/health-data.ios.ts
@@ -426,6 +426,7 @@ const acceptableDataTypes = {
   height: 'height',
   weight: 'bodyMass',
   heartRate: 'heartRate',
-  fatPercentage: 'bodyFatPercentage'
+  fatPercentage: 'bodyFatPercentage',
+  cardio: 'appleExerciseTime'
   // "nutrition" : ""
 };


### PR DESCRIPTION
I added the "cardio" data type, which refers to "Exercise Minutes" on iOS and "Heart Pts" on Android. Both types of data are equivalent:

### iOS. Exercise Minutes
**Description**: Every full minute of movement equal to or exceeding the intensity of a brisk walk counts toward your daily Exercise Minutes. (Source: Apple Health App)
**unit**: min

### Android. Heart Pts
**Description**: You score Heart Points for doing activities at a higher pace, like taking a brisk walk. Increase the intensity to earn more points.
[...] You earn one point for each minute of moderate activity, like a brisk walk that's over 100 steps per minute. [...] Each minute of vigorous activity scores you two Heart Points. (Source: Google Fit App)
**unit**: points
