### PR TITLE
Query aggregate data

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,33 @@ this.healthData.query(
     .catch(error => this.resultToShow = error);
 ```
 
+### `queryAggregateData`
+
+Difference between `query` and `queryAggregateData`: if you use `query`, you will probably find that the number of steps (or other types of data) do not match those shown by the Google Fit and Apple Health apps.  If you wanted to accurately compute the user's data then use: `queryAggregateData`
+
+Mandatory properties are `startData`, `endDate`, and `dataType`.
+The `dataType` must be one of the ['Available Data Types'](#available-data-types).
+
+By default data is aggregated by `day`.
+This plugin however offers a way to aggregate the data by either `hour` and `day`. (`month` and `year` available soon)
+
+Note that `queryAggregateData` only supports `steps`, `calories` and `distance` on Android. (More data types available soon).
+ 
+If you didn't run `requestAuthorization` before running `query`,
+the plugin will run `requestAuthorization` for you (for the requested `dataType`). You're welcome. 😉 
+
+```typescript
+this.healthData.queryAggregateData(
+    {
+      startDate: new Date(new Date().getTime() - 3 * 24 * 60 * 60 * 1000), // 3 days ago
+      endDate: new Date(), // now
+      dataType: "steps", // equal to the 'name' property of 'HealthDataType'
+      unit: "count", // make sure this is compatible with the 'dataType' (see below)
+      aggregateBy: "day", // optional, one of: "hour", "day" ; default: "day"
+    })
+    .then(result => console.log(JSON.stringify(result)))
+    .catch(error => this.resultToShow = error);
+```
 
 ### `startMonitoring` (iOS only, for now)
 If you want to be notified when health data was changed, you can monitor specific types.


### PR DESCRIPTION
If you use `query`, you will probably find that the number of steps (or other types of data) do not match those shown by the Google Fit and Apple Health apps.  If you wanted to accurately compute the user's data then use: `queryAggregateData`
### iOS (Apple Health)
The `query` method is over-counting steps because it simply sums the results of an `HKSampleQuery`. A sample query will return all samples matching the given predicate, including overlapping samples from multiple sources. If you wanted to accurately compute the user's step count using `HKSampleQuery`, you'd have to detect overlapping samples and avoid counting them, which would be tedious and difficult to do correctly.
Health uses `HKStatisticsQuery` and `HKStatisticsCollectionQuery` to compute aggregate values. These queries calculate the sum (and other aggregate values) for you, and do so efficiently. Most importantly, though, they de-duplicate overlapping samples to avoid over-counting.
The [documentation for HKStatisticsCollectionQuery](https://developer.apple.com/documentation/healthkit/hkstatisticscollectionquery) includes sample code.

### Android (Google Fit)
The Fit app does some additional processing on top of the steps. It estimates steps based on the activity when none are recorded.
You need to use a custom `DataSource` of the package `com.google.android.gms`.
You can find the solution on the [Google Fit API FAQ page](https://developers.google.com/fit/faq#get-step-count).

